### PR TITLE
simplify build script now that docker 19.03 beta3 has a fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ WORKDIR /src
 
 # build and cache dependencies as their own layer
 COPY rebar.config rebar.lock .
-# --mount=type=cache,target=/tmp/service_discovery/_build
 RUN --mount=type=cache,target=/root/.cache/rebar3 rebar3 compile
 
 # RUN --mount=target=. \

--- a/build.sh
+++ b/build.sh
@@ -21,33 +21,18 @@ GIT_REF=$(git rev-parse HEAD) # or with --short
 # takes the name of the image to build and the names of images to use as caches
 build_and_push() {
     local image=$1
-    shift
     local cache_images=("$@")
 
     # prepend --cache-from to each image to use as caches
     cache_images=( "${cache_images[@]/#/--cache-from=}" )
 
-    # if the image of the same tag already exists use it as a cache as well
-    if [[ "$(docker images -q ${image} 2> /dev/null)" == "" ]] && ! docker pull -q $image ; then
-        docker build --target builder --tag $image "${cache_images[@]}" \
-               --build-arg BUILDKIT_INLINE_CACHE=true -f Dockerfile .
-    else
-        docker build --target builder --tag $image --cache-from=$image "${cache_images[@]}" \
-               --build-arg BUILDKIT_INLINE_CACHE=true -f Dockerfile .
-    fi
+    docker build --target builder --tag $image --cache-from=$image "${cache_images[@]}" \
+           --build-arg BUILDKIT_INLINE_CACHE=true -f Dockerfile .
 
-    # return true so the script doesn't exit when push if alse
-    if $PUSH ; then
-        true
-    else
-        docker push $image
-    fi
+    ! $PUSH || docker push $image
 }
 
 build_and_push "$BUILD_IMAGE:$CHKSUM"
 build_and_push "$RELEASER_IMAGE:$GIT_REF" "$BUILD_IMAGE:$CHKSUM"
 build_and_push "$IMAGE:$GIT_REF" "$BUILD_IMAGE:$CHKSUM" "$RELEASER_IMAGE:$GIT_REF"
 build_and_push "$PLT_IMAGE:$CHKSUM" "$BUILD_IMAGE:$CHKSUM"
-
-# to run the plt image
-# docker run -v $(pwd):/src $PLT_IMAGE:$CHKSUM


### PR DESCRIPTION
beta3 fixes the bug where `--cache-from` could cause the build to fail. Now there is no need for an explicit `pull`, docker will try to pull if the image doesn't exist, or a check if the image exists since docker will ignore it if it doesn't and not fail.

Obviously we need to wait until 19.03 is a stable release to release the docker chapter. Hopefully that'll happen soon.