### PR TITLE
use acceptor_pool for elli acceptor pool which adds a grace period for shutdown

### DIFF
--- a/apps/service_discovery_http/src/sdh_conn.erl
+++ b/apps/service_discovery_http/src/sdh_conn.erl
@@ -1,0 +1,21 @@
+-module(sdh_conn).
+
+-behaviour(acceptor).
+
+-export([acceptor_init/3,
+         acceptor_continue/3,
+         acceptor_terminate/2]).
+
+acceptor_init(_, _LSocket, {Transport, ElliCallback, ElliOpts, SslOpts}) ->
+    {ok, {Transport, ElliCallback, ElliOpts, SslOpts}}.
+
+acceptor_continue(_PeerName, Socket, {ssl, ElliCallback, ElliOpts, SslOpts}) ->
+    {ok, AcceptSocket} = ssl:handshake(Socket, SslOpts),
+    elli_http:keepalive_loop({ssl, AcceptSocket}, ElliOpts, ElliCallback);
+acceptor_continue(_PeerName, Socket, {gen_tcp, ElliCallback, ElliOpts, _SslOpts}) ->
+    elli_http:keepalive_loop({plain, Socket}, ElliOpts, ElliCallback).
+
+acceptor_terminate(Reason, _) ->
+    % Something went wrong. Either the acceptor_pool is terminating or the
+    % accept failed.
+    exit(Reason).

--- a/apps/service_discovery_http/src/sdh_handler.erl
+++ b/apps/service_discovery_http/src/sdh_handler.erl
@@ -14,6 +14,13 @@ handle(Req, _Args) ->
 
 handle('GET', [<<"healthz">>], _Req) ->
     {ok, [], <<>>};
+handle('GET', [<<"ready">>], _Req) ->
+    case service_discovery_http_app:is_shutting_down() of
+        true ->
+            {503, [], <<>>};
+        _ ->
+            {ok, [], <<>>}
+    end;
 
 handle('GET', [<<"services">>], Req) ->
     Services = service_discovery:list(),

--- a/apps/service_discovery_http/src/sdh_pool.erl
+++ b/apps/service_discovery_http/src/sdh_pool.erl
@@ -1,0 +1,24 @@
+-module(sdh_pool).
+
+-behaviour(acceptor_pool).
+
+-export([start_link/2,
+         accept_socket/2]).
+
+-export([init/1]).
+
+start_link(ElliOpts, ListenOpts) ->
+    acceptor_pool:start_link({local, ?MODULE}, ?MODULE, [ElliOpts, ListenOpts]).
+
+accept_socket(Socket, Acceptors) ->
+    acceptor_pool:accept_socket(?MODULE, Socket, Acceptors).
+
+%% TODO: add ssl support
+init([ElliOpts, ListenOpts]) ->
+    ElliCallback = maps:get(callback, ElliOpts),
+
+    %% Grace gives a 5 second shutdown period for open connections
+    Conn = #{id => sdh_conn,
+             start => {sdh_conn, {gen_tcp, ElliCallback, maps:to_list(ElliOpts), ListenOpts}, []},
+             grace => timer:seconds(5)},
+    {ok, {#{}, [Conn]}}.

--- a/apps/service_discovery_http/src/sdh_socket.erl
+++ b/apps/service_discovery_http/src/sdh_socket.erl
@@ -1,0 +1,62 @@
+-module(sdh_socket).
+
+-behaviour(gen_server).
+
+-export([start_link/2]).
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         code_change/3,
+         terminate/2]).
+
+%% public api
+
+start_link(ListenOpts, AcceptorOpts) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [ListenOpts, AcceptorOpts], []).
+
+%% gen_server api
+
+init([ListenOpts, AcceptorOpts]) ->
+    Port = maps:get(port, ListenOpts, 3000),
+    IPAddress = maps:get(ip, ListenOpts, {0,0,0,0}),
+    AcceptorPoolSize = maps:get(pool_size, AcceptorOpts, 10),
+    SocketOpts = maps:get(socket_opts, ListenOpts, [{reuseaddr, true},
+                                                    {nodelay, true},
+                                                    {reuseaddr, true},
+                                                    {backlog, 32768},
+                                                    {keepalive, true}]),
+    % Trapping exit so can close socket in terminate/2
+    _ = process_flag(trap_exit, true),
+    Opts = [{active, false}, {mode, binary}, {packet, raw}, {ip, IPAddress} | SocketOpts],
+    case gen_tcp:listen(Port, Opts) of
+        {ok, Socket} ->
+            MRef = monitor(port, Socket),
+            sdh_pool:accept_socket(Socket, AcceptorPoolSize),
+            {ok, {Socket, MRef}};
+        {error, Reason} ->
+            {stop, Reason}
+    end.
+
+handle_call(Req, _, State) ->
+    {stop, {bad_call, Req}, State}.
+
+handle_cast(Req, State) ->
+    {stop, {bad_cast, Req}, State}.
+
+handle_info({'DOWN', MRef, port, Socket, Reason}, {Socket, MRef} = State) ->
+    {stop, Reason, State};
+handle_info(_, State) ->
+    {noreply, State}.
+
+code_change(_, State, _) ->
+    {ok, State}.
+
+terminate(_, {Socket, MRef}) ->
+    % Socket may already be down but need to ensure it is closed to avoid
+    % eaddrinuse error on restart
+    case demonitor(MRef, [flush, info]) of
+        true  -> gen_tcp:close(Socket);
+        false -> ok
+    end.

--- a/apps/service_discovery_http/src/service_discovery_http.app.src
+++ b/apps/service_discovery_http/src/service_discovery_http.app.src
@@ -8,6 +8,7 @@
     stdlib,
     service_discovery,
     jsx,
+    acceptor_pool,
     elli
    ]},
   {env,[]},

--- a/apps/service_discovery_http/src/service_discovery_http_app.erl
+++ b/apps/service_discovery_http/src/service_discovery_http_app.erl
@@ -3,10 +3,23 @@
 -behavior(application).
 
 -export([start/2,
+         prep_stop/1,
          stop/1]).
 
+-export([is_shutting_down/0]).
+
+-define(IS_SHUTTING_DOWN, {?MODULE, is_shutting_down}).
+
 start(_, _) ->
-    service_discovery_http_sup:start_link().
+    Env = application:get_all_env(service_discovery_http),
+    service_discovery_http_sup:start_link(Env).
+
+prep_stop(State) ->
+    persistent_term:put(?IS_SHUTTING_DOWN, true),
+    State.
 
 stop(_) ->
     ok.
+
+is_shutting_down() ->
+    persistent_term:get(?IS_SHUTTING_DOWN, false).

--- a/apps/service_discovery_http/src/service_discovery_http_sup.erl
+++ b/apps/service_discovery_http/src/service_discovery_http_sup.erl
@@ -7,25 +7,53 @@
 
 -behaviour(supervisor).
 
--export([start_link/0]).
+-export([start_link/1]).
 
 -export([init/1]).
 
--define(SERVER, ?MODULE).
+-define(DEFAULT_ELLI_OPTS, #{callback => {sdh_handler, []},
+                             accept_timeout => 10000,
+                             request_timeout => 60000,
+                             header_timeout => 10000,
+                             body_timeout => 30000,
+                             max_body_size => 1024000}).
+-define(DEFAULT_LISTEN_OPTS, #{port => 3000,
+                               socket_opts => [{reuseaddr, true},
+                                               {nodelay, true},
+                                               {reuseaddr, true},
+                                               {backlog, 32768},
+                                               {keepalive, true}]}).
+-define(DEFAULT_ACCEPTOR_OPTS, #{pool_size => 10}).
 
-start_link() ->
-    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+start_link(Opts) ->
+    ElliOpts = proplists:get_value(elli_opts, Opts, #{}),
+    ListenOpts = proplists:get_value(listen_opts, Opts, #{}),
+    AcceptorOpts = proplists:get_value(acceptor_opts, Opts, #{}),
+    start_link(ElliOpts, ListenOpts, AcceptorOpts).
 
-init([]) ->
-    ElliOpts = [{callback, sdh_handler},
-                {port, 3000}],
-    ElliSpec = #{id => sdh_handler,
-                 start => {elli, start_link, [ElliOpts]},
-                 restart => permanent,
-                 shutdown => 5000,
-                 type => worker,
-                 modules => [sdh_handler]},
-    SupFlags = #{strategy => one_for_one,
-                 intensity => 5,
-                 period => 10},
-    {ok, {SupFlags, [ElliSpec]}}.
+start_link(ElliOpts, ListenOpts, AcceptorOpts) ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, [maps:merge(?DEFAULT_ELLI_OPTS, ElliOpts),
+                                                      maps:merge(?DEFAULT_LISTEN_OPTS, ListenOpts),
+                                                      maps:merge(?DEFAULT_ACCEPTOR_OPTS, AcceptorOpts)]).
+
+init([ElliOpts, ListenOpts, AcceptorOpts]) ->
+    RestartStrategy = #{strategy => rest_for_one,
+                        intensity => 5,
+                        period => 10},
+    Pool = #{id => sdh_pool,
+             start => {sdh_pool, start_link, [ElliOpts, ListenOpts]},
+             restart => permanent,
+             shutdown => 5000,
+             type => worker,
+             modules => [sdh_handler]},
+    Socket = #{id => sdh_socket,
+               start => {sdh_socket, start_link, [ListenOpts, AcceptorOpts]},
+               restart => permanent,
+               shutdown => 5000,
+               type => worker,
+               modules => [sdh_socket]},
+
+    %% NOTE: The order is important here. Socket is terminated first when the supervisor stops.
+    %% This means the listen socket will be closed before the pool of acceptors will shutdown.
+    %% We want the listen socket to stop listening before we start shutting down acceptors.
+    {ok, {RestartStrategy, [Pool, Socket]}}.

--- a/deployment/base/deployment.yaml
+++ b/deployment/base/deployment.yaml
@@ -4,6 +4,11 @@ metadata:
   name: service-discovery
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 25%
   template:
     spec:
       containers:
@@ -28,15 +33,14 @@ spec:
 
         readinessProbe:
           httpGet:
-            path: /healthz
-            port: 3000
-          initialDelaySeconds: 1
+            path: /ready
+            port: http
+          initialDelaySeconds: 3
           periodSeconds: 5
 
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 3000
+            port: http
           initialDelaySeconds: 3
-          periodSeconds: 10
-      
+          periodSeconds: 15


### PR DESCRIPTION
In addition to ensuring the listen socket is closed first and a grace period of
5 seconds is given for open connections, during prep_stop of the http app
a persistent_term is set that eacy /ready check uses to know if it should return
503 or 200. 503 tells kubernetes to remove it from the pods receiving traffic.